### PR TITLE
comment out static folders for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,9 @@ Desktop.ini
 $RECYCLE.BIN/
 
 # static from other projects
-e2immu-support-javadoc/
-road-to-immutability*
-manual*
+#e2immu-support-javadoc/
+#road-to-immutability*
+#manual*
 
 # OSX
 .DS_Store


### PR DESCRIPTION
Found documentation folders in .gitignore. Have commented for now to ensure e2immu-documentation's GH action is able to push documentation here.